### PR TITLE
Cockpit view fixes

### DIFF
--- a/A319neo-set.xml
+++ b/A319neo-set.xml
@@ -67,7 +67,7 @@
 				<from-model type="bool">true</from-model>
 				<x-offset-m archive="y">0</x-offset-m>
 				<y-offset-m archive="y">2.2435023</y-offset-m>
-				<z-offset-m archive="y">-12.1</z-offset-m>
+				<z-offset-m archive="y">-11.97</z-offset-m>
 				<pitch-offset-deg archive="y">40</pitch-offset-deg>
 			</config>
 		</view>
@@ -79,7 +79,7 @@
 				<from-model type="bool">true</from-model>
 				<x-offset-m archive="y">-0.10</x-offset-m>
 				<y-offset-m archive="y">1.98</y-offset-m>
-				<z-offset-m archive="y">-14.39</z-offset-m>
+				<z-offset-m archive="y">-12.79</z-offset-m>
 				<pitch-offset-deg archive="y">-75</pitch-offset-deg>
 			</config>
 		</view>
@@ -92,7 +92,7 @@
 				<from-model type="bool">true</from-model>
 				<x-offset-m archive="y">0</x-offset-m>
 				<y-offset-m archive="y">2.21</y-offset-m>
-				<z-offset-m archive="y">-13.96</z-offset-m>
+				<z-offset-m archive="y">-12.36</z-offset-m>
 				<pitch-offset-deg archive="y">-75</pitch-offset-deg>
 			</config>
 		</view>

--- a/A320neo-set.xml
+++ b/A320neo-set.xml
@@ -89,7 +89,7 @@
 				<from-model type="bool">true</from-model>
 				<x-offset-m archive="y">0</x-offset-m>
 				<y-offset-m archive="y">2.2435023</y-offset-m>
-				<z-offset-m archive="y">-13.73</z-offset-m>
+				<z-offset-m archive="y">-13.6</z-offset-m>
 				<pitch-offset-deg archive="y">40</pitch-offset-deg>
 			</config>
 		</view>

--- a/A321neo-set.xml
+++ b/A321neo-set.xml
@@ -77,7 +77,7 @@
 			<internal archive="y">true</internal>
 			<config>
 				<x-offset-m archive="y">-0.525</x-offset-m>
-				<y-offset-m archive="y">2.45</y-offset-m>
+				<y-offset-m archive="y">2.35</y-offset-m>
 				<z-offset-m archive="y">-17.87</z-offset-m>
 				<pitch-offset-deg archive="y">-10.0</pitch-offset-deg>
 			</config>
@@ -89,8 +89,8 @@
 			<config>
 				<from-model type="bool">true</from-model>
 				<x-offset-m archive="y">0</x-offset-m>
-				<y-offset-m archive="y">2.2435023</y-offset-m>
-				<z-offset-m archive="y">-18</z-offset-m>
+				<y-offset-m archive="y">2.29</y-offset-m>
+				<z-offset-m archive="y">-17.87</z-offset-m>
 				<pitch-offset-deg archive="y">40</pitch-offset-deg>
 			</config>
 		</view>
@@ -126,9 +126,9 @@
 			<config>
 				<from-model type="bool">true</from-model>
 				<x-offset-m archive="y">0.525</x-offset-m>
-				<y-offset-m archive="y">2.45</y-offset-m>
+				<y-offset-m archive="y">2.35</y-offset-m>
 				<z-offset-m archive="y">-17.87</z-offset-m>
-				<pitch-offset-deg archive="y">-15.0</pitch-offset-deg>
+				<pitch-offset-deg archive="y">-10.0</pitch-offset-deg>
 			</config>
 		</view>
 


### PR DESCRIPTION
Some elementary fixes to make:
- A319 instrument (FMGC, Pedestal and Overhead panel) work at all
- A321 pilot and copilot view have correct height. For some reason the A321 model is slightly lower. It would be worth looking into aligning it back to the same level as the other two, but for now this might do.
- Adjust the Overhead panel to have the fuel pumps (that need to be turned on before starting engines) and hydraulic pumps fit in the default view.
